### PR TITLE
Use canonicalize temp path for TestClient

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ impl TestClient {
     pub fn new(name: &str, configs: &[&str]) -> Self {
         env::set_var("HGUSER", "test");
 
-        let tmp = env::temp_dir();
+        let tmp = env::temp_dir().canonicalize().unwrap();
         let path = tmp.join(name);
         if path.exists() {
             let _ = fs::remove_dir_all(&path);


### PR DESCRIPTION
 /tmp a symlink to /private/tmp  on MACOS.
 It occur a test_show_source fail due to the different source path.
```rust
assert!(config.iter().any(|x| *x
        == Config {
            source: Some(c.get_path(".hg/hgrc") + ":2"),
            section: "section".to_string(),
            key: "key".to_string(),
            value: "value".to_string(),
        }));
```